### PR TITLE
Fix example code for AreaChart

### DIFF
--- a/docs/examples/main.js
+++ b/docs/examples/main.js
@@ -272,11 +272,11 @@ var Demos = React.createClass({
 `<AreaChart
   data={areaData}
   width="100%"
-  height={300}
+  height={400}
   viewBoxObject={
     x: 0,
     y: 0,
-    heigth: 400,
+    height: 400,
     width: 500
   }
   xAxisTickInterval={{unit: 'year', interval: 2}}


### PR DESCRIPTION
# The Greeting
:wave: Hello, friendly react-d3 people! 

I really love what you're doing here. Definitely going to look into contributing more than a docfix. :grin: 

# The Patch
Example code for AreaChart had a typo in the viewBoxObject (heigth),
and the height prop on the component was different than the height
prop inside the viewBoxObject. 

# The Well-Wishing
Happy New Year! :confetti_ball: 